### PR TITLE
chore: fix CI, release scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
+      - beta
 jobs:
   commit-checks:
     name: Lint, test, and build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
 
+      - name: NPM authentication
+        run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+
       - name: Install packages
         run: npm ci --legacy-peer-deps
       

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node_modules/
 # Optional npm cache directory
 .npm
 
+# npm config
+.npmrc
+
 # Optional eslint cache
 .eslintcache
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true


### PR DESCRIPTION
## Description

- Prevent running multiple CI workflows that can push commits
- Add `NPM_TOKEN` secret, use it to authentify for publishing