### PR TITLE
chore: fix NPM auth

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -15,6 +15,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
 
+      - name: NPM authentication
+        run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+
       - name: Install packages
         run: npm ci --legacy-peer-deps
       

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-        "release:latest": "release-it --ci --git.requireBranch=main",
-        "release:beta": "release-it --ci --git.requireBranch=beta --preRelease=beta",
+        "release:latest": "release-it --ci --git.requireBranch=main --npm.skipChecks",
+        "release:beta": "release-it --ci --git.requireBranch=beta --preRelease=beta --npm.skipChecks",
         "release:preview": "release-it --dry-run"
     },
     "devDependencies": {


### PR DESCRIPTION
## Description

- Add missing call to `NPM_TOKEN` in prerelease script
- Skip NPM identity checks when releasing from CI workflows