### PR TITLE
ci: update changelog settings

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -24,7 +24,6 @@
     },
     "plugins": {
         "@release-it/conventional-changelog": {
-            "from": "b4ca6af1b7367c14d931a8d6815286ca7aa112e6",
             "header": "# Changelog",
             "infile": "CHANGELOG.md",
             "skipUnstable": true,

--- a/.release-it.json
+++ b/.release-it.json
@@ -9,7 +9,7 @@
         ]
     },
     "git": {
-        "commitMessage": "chore: release ${version}",
+        "commitMessage": "release: v${version}",
         "tag": true,
         "tagMatch": "[0-9]*\\.[0-9]*\\.[0-9]*"
     },
@@ -56,6 +56,14 @@
                     },
                     {
                         "type": "auto-commit",
+                        "hidden": true
+                    },
+                    {
+                        "type": "release",
+                        "hidden": true
+                    },
+                    {
+                        "type": "ci",
                         "hidden": true
                     }
                 ]

--- a/.release-it.json
+++ b/.release-it.json
@@ -15,8 +15,6 @@
     },
     "github": {
         "assets": ["extension.css", "extension.js"],
-        "autoGenerate": true,
-        "draft": true,
         "release": true,
         "releaseName": "v${version}"
     },

--- a/.release-it.json
+++ b/.release-it.json
@@ -26,8 +26,10 @@
     },
     "plugins": {
         "@release-it/conventional-changelog": {
+            "from": "v0.2.0",
             "header": "# Changelog",
             "infile": "CHANGELOG.md",
+            "skipUnstable": true,
             "strictSemVer": true,
             "preset": {
                 "name": "conventionalcommits",

--- a/.release-it.json
+++ b/.release-it.json
@@ -26,7 +26,7 @@
     },
     "plugins": {
         "@release-it/conventional-changelog": {
-            "from": "v0.2.0",
+            "from": "b4ca6af1b7367c14d931a8d6815286ca7aa112e6",
             "header": "# Changelog",
             "infile": "CHANGELOG.md",
             "skipUnstable": true,

--- a/.release-it.json
+++ b/.release-it.json
@@ -24,6 +24,7 @@
     },
     "plugins": {
         "@release-it/conventional-changelog": {
+            "from": "0.2.0",
             "header": "# Changelog",
             "infile": "CHANGELOG.md",
             "skipUnstable": true,

--- a/.release-it.json
+++ b/.release-it.json
@@ -24,7 +24,9 @@
     },
     "plugins": {
         "@release-it/conventional-changelog": {
-            "from": "0.2.0",
+            "gitRawCommitsOpts": {
+                "from": "3c159c0ecfa242be0780c700f339c0876449c10e"
+            },
             "header": "# Changelog",
             "infile": "CHANGELOG.md",
             "skipUnstable": true,


### PR DESCRIPTION
## Description

Improve automated release, especially the changelog:
- Use conventional commit changelog instead of GitHub-generated, for GH releases
- Automatically publish GitHub releases, rather than keeping them as draft
- Restrict changelog range to after `v0.2.0` commit
- Change git commit type from `chore` to `release`
- Exclude `ci`, `release` commits from changelog