### PR TITLE
ci(changelog): customize release notes format

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-        "release:latest": "release-it --ci --git.requireBranch=main --npm.skipChecks",
-        "release:beta": "release-it --ci --git.requireBranch=beta --preRelease=beta --github.release=false --npm.skipChecks",
+        "release:latest": "release-it --ci --git.requireBranch=main --github.releaseNotes=\"npx auto-changelog --stdout -p\" --npm.skipChecks",
+        "release:beta": "release-it --ci --git.requireBranch=beta --preRelease=beta --github.releaseNotes=\"echo\" --npm.skipChecks",
         "release:preview": "release-it --dry-run"
     },
     "devDependencies": {


### PR DESCRIPTION
## Description

If released to `latest`, use changelog for current package version as release notes.
If released to `beta`, post empty release notes.