### PR TITLE
infra: fix version bumping script

### DIFF
--- a/.github/workflows/create-prerelease.yaml
+++ b/.github/workflows/create-prerelease.yaml
@@ -26,11 +26,10 @@ jobs:
         run: |
           npm run version:beta
 
-      # https://github.com/peter-evans/create-pull-request#action-outputs
       - name: Create Pull Request
-        id: cpr
         uses: peter-evans/create-pull-request@v4
         with:
+          base: beta
           branch: release/beta
           delete-branch: true
           draft: false

--- a/.github/workflows/create-prerelease.yaml
+++ b/.github/workflows/create-prerelease.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: main
+          ref: beta
 
       - uses: actions/setup-node@v2
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -22,6 +22,13 @@ jobs:
       - name: Install packages
         run: npm ci --legacy-peer-deps
 
+      - name: Get next version
+        id: version
+        run: |
+          next_version=$(npx release-it --release-version)
+          echo $next_version
+          echo "::set-output name=next::$next_version"
+
       - name: Get changelog
         id: changelog
         run: |
@@ -42,7 +49,7 @@ jobs:
           delete-branch: true
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
-          title: "chore(release): publish latest"
+          title: "chore(release): v${{ steps.version.outputs.next }}"
           commit-message: "auto-commit: staged changes"
           labels: release
           body: |

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -40,11 +40,10 @@ jobs:
         run: |
           npm run version:latest
 
-      # https://github.com/peter-evans/create-pull-request#action-outputs
       - name: Create Pull Request
-        id: cpr
         uses: peter-evans/create-pull-request@v4
         with:
+          base: main
           branch: release/latest
           delete-branch: true
           draft: false

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-		"version": "release-it --ci --no-git.tag --no-git.push --no-npm --no-github.release",
+		"version": "release-it --ci --no-git.tag --no-git.push --no-npm.publish --no-github.release",
 		"version:latest": "npm run version",
 		"version:beta": "npm run version -- --preRelease=beta",
 		"publish": "release-it --ci --npm.skipChecks --no-increment",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-		"version": "release-it --ci --no-git.tag --no-npm.publish --no-github.release",
+		"version": "release-it --ci --no-git --no-npm.publish --no-github.release",
 		"version:latest": "npm run version",
 		"version:beta": "npm run version -- --preRelease=beta",
 		"publish": "release-it --ci --npm.skipChecks --no-increment",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-		"version": "release-it --ci --no-git.tag --no-git.push --no-npm.publish --no-github.release",
+		"version": "release-it --ci --no-git.tag --no-npm.publish --no-github.release",
 		"version:latest": "npm run version",
 		"version:beta": "npm run version -- --preRelease=beta",
 		"publish": "release-it --ci --npm.skipChecks --no-increment",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-		"version": "release-it --ci --no-git --no-npm --no-github.release",
+		"version": "release-it --ci --no-git.tag --no-git.push --no-npm --no-github.release",
 		"version:latest": "npm run version",
 		"version:beta": "npm run version -- --preRelease=beta",
 		"publish": "release-it --ci --npm.skipChecks --no-increment",


### PR DESCRIPTION
## Description

- Fix bad use of `--no-npm` : it prevents version bumping in `package.json`, so need to use `--no-npm.publish` instead.
- Fix checkout ref for `create-prerelease.yaml`
- Add explicit base for creating PRs
- Use next version in PR title when releasing as latest