### PR TITLE
infra: explicitly create release branch in workflows

### DIFF
--- a/.github/workflows/create-prerelease.yaml
+++ b/.github/workflows/create-prerelease.yaml
@@ -6,12 +6,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Setup release branch
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: beta
 
+      - name: Create release branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: 'release/beta'
+
+      # Push commit from release-it: version bump, changelog, build
       - uses: actions/setup-node@v2
 
       - name: NPM authentication
@@ -29,6 +38,7 @@ jobs:
         run: |
           npm run version:beta
 
+      # Create PR for release branch
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/create-prerelease.yaml
+++ b/.github/workflows/create-prerelease.yaml
@@ -7,18 +7,18 @@ jobs:
 
     steps:
       # Setup release branch
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: beta
-
       - name: Create release branch
         uses: peterjgrainger/action-create-branch@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: 'release/beta'
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: release/beta
 
       # Push commit from release-it: version bump, changelog, build
       - uses: actions/setup-node@v2

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -6,12 +6,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Setup release branch
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: main
 
+      - name: Create release branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: 'release/latest'
+
+      # Push commit from release-it: version bump, changelog, build
       - uses: actions/setup-node@v2
 
       - name: NPM authentication
@@ -43,6 +52,7 @@ jobs:
         run: |
           npm run version:latest
 
+      # Create PR for release branch
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -7,18 +7,18 @@ jobs:
 
     steps:
       # Setup release branch
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: main
-
       - name: Create release branch
         uses: peterjgrainger/action-create-branch@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: 'release/latest'
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: release/latest
 
       # Push commit from release-it: version bump, changelog, build
       - uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "build-storybook": "build-storybook --quiet",
         "test-storybook": "test-storybook",
         "ci:test-storybook": "test-storybook --coverage",
-		"version": "release-it --ci --no-git --no-npm.publish --no-github.release",
+		"version": "release-it --ci --no-git.tag --no-npm.publish --no-github.release",
 		"version:latest": "npm run version",
 		"version:beta": "npm run version -- --preRelease=beta",
 		"publish": "release-it --ci --npm.skipChecks --no-increment",


### PR DESCRIPTION
## Description

Update release setup, by adding a step that creates the required release branch (`release/latest` or `release/beta`) before running `release-it` and attempting to create a PR.

This should get around the PR creation issues ("no diff"), and make it simpler to call `release-it` because committing should now be safe.