### PR TITLE
infra: improve release workflows

### DIFF
--- a/.github/workflows/create-prerelease.yaml
+++ b/.github/workflows/create-prerelease.yaml
@@ -4,28 +4,29 @@ jobs:
   createReleasePR:
     name: Create PR for release
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_BRANCH: "release/beta"
 
     steps:
       # Setup release branch
       - name: Delete existing branch
         uses: dawidd6/action-delete-branch@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branches: 'release/beta'
+          github_token: ${{ env.GITHUB_TOKEN }}
+          branches: ${{ env.RELEASE_BRANCH }}
         continue-on-error: true
 
       - name: Create release branch
         uses: peterjgrainger/action-create-branch@v2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: 'release/beta'
+          branch: ${{ env.RELEASE_BRANCH }}
 
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: release/beta
+          ref: ${{ env.RELEASE_BRANCH }}
 
       # Push commit from release-it: version bump, changelog, build
       - uses: actions/setup-node@v2
@@ -41,7 +42,7 @@ jobs:
       - name: Install packages
         run: npm ci --legacy-peer-deps
 
-      - name: Stage changes to version, changelog, build
+      - name: Bump version, build
         run: |
           npm run version-release:beta
 
@@ -51,8 +52,8 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "beta"
-          source_branch: "release/beta"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: ${{ env.RELEASE_BRANCH }}
+          github_token: ${{ env.GITHUB_TOKEN }}
           pr_draft: false
           pr_label: release
           pr_title: "chore(release): publish beta"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Get next version
         id: version
         run: |
-          next_version=$(npx release-it --release-version)
+          next_version=$(npx release-it --release-version | tail -1)
           echo $next_version
           echo "::set-output name=next::$next_version"
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -4,28 +4,29 @@ jobs:
   createReleasePR:
     name: Create PR for release
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_BRANCH: "release/latest"
 
     steps:
       # Setup release branch
       - name: Delete existing branch
         uses: dawidd6/action-delete-branch@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branches: 'release/latest'
+          github_token: ${{ env.GITHUB_TOKEN }}
+          branches: ${{ env.RELEASE_BRANCH }}
         continue-on-error: true
 
       - name: Create release branch
         uses: peterjgrainger/action-create-branch@v2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          branch: 'release/latest'
+          branch: ${{ env.RELEASE_BRANCH }}
 
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: release/latest
+          ref: ${{ env.RELEASE_BRANCH }}
 
       # Push commit from release-it: version bump, changelog, build
       - uses: actions/setup-node@v2
@@ -55,7 +56,7 @@ jobs:
           echo $changelog
           echo "::set-output name=changelog::$changelog"
 
-      - name: Stage changes to version, changelog, build
+      - name: Bump version, build
         run: |
           npm run version-release:latest
 
@@ -72,8 +73,8 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           destination_branch: "main"
-          source_branch: "release/latest"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: ${{ env.RELEASE_BRANCH }}
+          github_token: ${{ env.GITHUB_TOKEN }}
           pr_draft: false
           pr_label: release
           pr_title: "chore(release): v${{ steps.version.outputs.next }}"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -59,6 +59,13 @@ jobs:
         run: |
           npm run version-release:latest
 
+      - name: Update changelog
+        run: |
+          npx auto-changelog
+          git add CHANGELOG.md
+          git commit -m "📝 Update CHANGELOG"
+          git push origin ${{ env.RELEASE_BRANCH }} --progress --porcelain
+
       # Create PR for release branch
       - name: Create Pull Request
         id: cpr

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,8 +1,7 @@
 {
     "hooks": {
         "after:bump": [
-            "npm run build:roam",
-            "npx auto-changelog"
+            "npm run build:roam"
         ]
     },
     "git": {


### PR DESCRIPTION
## Description

Add refinements for release/prerelease workflows:
- `auto-changelog` is taken out of `release-it` lifecycle: it doesn't update the file when called after the version bump, and is only needed for latest releases, so the command is moved to `create-release.yaml` as a separate step
- `tail -1` is added to the workflow step that retrieves the next version, to avoid capturing `WARNING`s
- `GITHUB_TOKEN` and `RELEASE_BRANCH` variables are moved to the workflow `env`, to avoid duplications