### PR TITLE
infra: fix changelog update step in workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -62,10 +62,11 @@ jobs:
 
       - name: Update changelog
         run: |
-          npx auto-changelog
+          npx auto-changelog -p
           git add CHANGELOG.md
           git commit -m "📝 Update CHANGELOG"
           git push origin ${{ env.RELEASE_BRANCH }} --progress --porcelain
+        continue-on-error: true
 
       # Create PR for release branch
       - name: Create Pull Request


### PR DESCRIPTION
## Description

Allow errors in changelog step in `create-release.yaml` workflow. It's [still not updating](https://github.com/alixlahuec/latex-roam/actions/runs/3260353183/jobs/5353851895) the changelog.

The PR also adds the `-p` parameter, which doesn't work locally but _might_ work in workflow runs.