### PR TITLE
infra: fix bad use of GITHUB_REF in dist workflow

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -53,15 +53,15 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - run: |
-          echo "${GITHUB_REF}"
-          echo "${GITHUB_REF##*/}"
+          echo "GitHub ref is ${{ github.ref }}"
+          echo "GitHub ref name is ${{ github.ref_name }}"
 
       - name: Publish release @beta
-        if: ${GITHUB_REF##*/} == 'beta'
+        if: ${{ github.ref_name == 'beta' }}
         run: |
           npm run publish:beta
 
       - name: Publish release @latest
-        if: ${GITHUB_REF##*/} == 'main'
+        if: ${{ github.ref_name == 'main' }}
         run: |
           npm run publish:latest


### PR DESCRIPTION
## Description

Fix bad syntax for checking the workflow's `ref`, by using [proper context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context). Logic is simplified by using `ref_name` directly.